### PR TITLE
Stop mutating passed in config

### DIFF
--- a/seq_stream.js
+++ b/seq_stream.js
@@ -16,7 +16,7 @@ class SeqStream extends stream.Writable {
     constructor(config) {        
         super();
         
-        let loggerConfig = config || {};
+        let loggerConfig = config == null ? {} : {...config};
         let onError = loggerConfig.onError || function() {};
         loggerConfig.onError = (e) => {
             this.emit('error', e);


### PR DESCRIPTION
If we're passed config options, let's not mutate an object we don't own.