### PR TITLE
Feature/beacon - companion merge request to add flushToBeacon()

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "mocha": "^5.2.0"
   },
   "dependencies": {
-    "seq-logging": "^0.2.0"
+    "seq-logging": "^0.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "mocha": "^5.2.0"
   },
   "dependencies": {
-    "seq-logging": "^0.3.1"
+    "seq-logging": "^0.4.0"
   }
 }

--- a/seq_stream.js
+++ b/seq_stream.js
@@ -61,6 +61,15 @@ class SeqStream extends stream.Writable {
     flush() {
         return this._logger.flush();
     }
+
+    // A browser only function that queues events for sending using the
+    // navigator.sendBeacon() API.  This may work in an unload or pagehide event
+    // handler when a normal flush() would not.
+    // Events over 63K in length are discarded (with a warning sent in its place) 
+    // and the total size batch will be no more than 63K in length.
+    flushToBeacon() {
+        return this._logger.flushToBeacon();
+    }
 }
 
 module.exports = SeqStream;


### PR DESCRIPTION
This is to finish implementing datalust/seq-logging#9 and depends on datalust/seq-logging#10.

It only adds the pass-through call to `this._logger.flushToBeacon();` and I wasn't sure how to best manage this.  I also updated the package.json to require a future (non-existent) version of `seq-logger`.