### PR TITLE
Release v0.5.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,15 +24,9 @@ build: none
 test_script:
 - cmd: npm test
 deploy_script:
-- ps: >-
-    if ($env:APPVEYOR_REPO_BRANCH -ne 'main') { exit } 
+- cmd: >-
+    echo //registry.npmjs.org/:_authToken=%NPM_TOKEN%> .npmrc
+
+    node --version
         
-    $ErrorActionPreference = "SilentlyContinue"
-    
-    echo "//registry.npmjs.org/:_authToken=$env:NPM_TOKEN`n" | out-file "./.npmrc" -Encoding ASCII
-    
-    npm publish 2>&1
-    
-    trap { "Error: $_" }
-    
-    $LastExitCode = 0
+    if %APPVEYOR_REPO_BRANCH% equ main npm publish

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bunyan-seq",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -127,13 +127,13 @@
       "dev": true
     },
     "bunyan": {
-      "version": "1.8.12",
-      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.12.tgz",
-      "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.14.tgz",
+      "integrity": "sha512-LlahJUxXzZLuw/hetUQJmRgZ1LF6+cr5TPpRj6jf327AsiIq2jhYEH4oqUUkVKTor+9w2BT3oxVwhzE5lw9tcg==",
       "dev": true,
       "requires": {
         "dtrace-provider": "~0.8",
-        "moment": "^2.10.6",
+        "moment": "^2.19.3",
         "mv": "~2",
         "safe-json-stringify": "~1"
       }
@@ -278,13 +278,13 @@
       "dev": true
     },
     "dtrace-provider": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.7.tgz",
-      "integrity": "sha1-3JObTT4GIM/gwc2APQ0tftBP/QQ=",
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.8.tgz",
+      "integrity": "sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==",
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.10.0"
+        "nan": "^2.14.0"
       }
     },
     "emoji-regex": {
@@ -664,9 +664,9 @@
       }
     },
     "moment": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
       "dev": true,
       "optional": true
     },
@@ -689,15 +689,15 @@
       }
     },
     "nan": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
       "dev": true,
       "optional": true
     },
     "ncp": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
       "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
       "dev": true,
       "optional": true
@@ -858,7 +858,7 @@
     },
     "rimraf": {
       "version": "2.4.5",
-      "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
       "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
       "dev": true,
       "optional": true,
@@ -885,9 +885,9 @@
       "dev": true
     },
     "seq-logging": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/seq-logging/-/seq-logging-0.4.3.tgz",
-      "integrity": "sha512-9szsw0EmmyFodhqerQOPnw83DnzNangujFtKJHD0xsCC+FeBom/HKBTQG32Kq0sRUih0mSlKApTbFQWugRoSQA=="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/seq-logging/-/seq-logging-0.5.0.tgz",
+      "integrity": "sha512-j6rGQTuWTEONEeMVO1Mmjsc5P8r1NVGU/V70VxcKJGDL4n5MpYITcNM99+DHEfwx1D6QizURn+xmFpMIR6ETFA=="
     },
     "set-blocking": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bunyan-seq",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A Bunyan stream that sends log events to Seq",
   "main": "index.js",
   "scripts": {
@@ -26,13 +26,13 @@
   },
   "homepage": "https://github.com/continuousit/bunyan-seq#readme",
   "devDependencies": {
-    "bunyan": "^1.8.0",
+    "bunyan": "^1.8.14",
     "mocha": "^7.2.0",
     "sinon": "^9.0.2"
   },
   "dependencies": {
     "commander": "^5.1.0",
-    "seq-logging": "^0.4.0",
+    "seq-logging": "^0.5.0",
     "split2": "^3.1.1"
   }
 }


### PR DESCRIPTION
* Now uses `seq-logger@0.5.0` which is more stable (doesn't crash) and handles circular JSON objects.