### PR TITLE
Another attempt at valid TypeScript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,12 +9,20 @@ declare namespace BunyanSeq {
     eventSizeLimit?: number;
     batchSizeLimit?: number;
     name?: string;
-    level: string;
+    level?: string;
     reemitErrorEvents?: boolean;
     onError?: (e: Error) => void;
   }
 
-  function createStream(config: SeqStreamConfig): Writable;
+  interface SeqBunyanStream {
+    name?: string;
+    level?: string;
+    type: 'raw';
+    stream: Writable,
+    reemitErrorEvents?: boolean
+  }
+
+  function createStream(config: SeqStreamConfig): SeqBunyanStream;
 
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bunyan-seq",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A Bunyan stream that sends log events to Seq",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
https://github.com/datalust/bunyan-seq/commit/489d4fe7842e55704ea26f3f6802038daf5ebd64#commitcomment-53548890

The object returned from `createStream()` isn't the `Writable` stream itself (reverting to an earlier scheme for these types).
